### PR TITLE
Bump numpy version to < 2.0

### DIFF
--- a/dev_notes.md
+++ b/dev_notes.md
@@ -53,7 +53,7 @@ mpirun -n 9 ./unit_tests --gtest_filter=CartesianTopology.*
 * Python 3.7+
 * mpi4py
 * PyTorch
-* NumPy >= 1.18
+* NumPy >= 1.18 < 2.0
 * nptyping (`pip install nptyping`)
 * numba
 * typing-extensions if < 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,7 @@ package_dir=
 packages=find:
 
 install_requires =
-# 1.24 currently conflicts with numba
-    numpy >=1.18.0, <1.24.0
+    numpy >=1.18.0, <2.0
     numba
     mpi4py
     torch


### PR DESCRIPTION
To run with Python 3.12, a more recent numpy version is required.
Tested only with: `python -m unittest discover tests`